### PR TITLE
Nut retry

### DIFF
--- a/test/nuts/all-commands.nut.ts
+++ b/test/nuts/all-commands.nut.ts
@@ -39,10 +39,15 @@ describe('plugin-community commands', () => {
   });
 
   describe('community:template:list', () => {
-    it('ensures templates:list, uh, lists... templates', () => {
+    it('ensures templates:list lists templates', () => {
       // locally --user is set with the `TESTKIT_HUB_USERNAME` env var.
       const cmd = 'force:community:template:list --json';
-      const output = execCmd<CommunityTemplatesListResponse>(cmd, { ensureExitCode: 0 }).jsonOutput;
+      let output = execCmd<CommunityTemplatesListResponse>(cmd, { ensureExitCode: 0 }).jsonOutput;
+
+      // There seems to be a race condition where this will sometimes fail on the first try.
+      if (!output) {
+        output = execCmd<CommunityTemplatesListResponse>(cmd, { ensureExitCode: 0 }).jsonOutput;
+      }
 
       expect(output.result).to.have.all.keys(['templates', 'total']);
       expect(output.result.templates[0]).to.have.all.keys(['publisher', 'templateName']);


### PR DESCRIPTION
### What does this PR do?
The first NUT will occasionally fail. `output` is `undefined`. Adding a retry seems to solve it.

### What issues does this PR fix or reference?
[skip-validate-pr]