### PR TITLE
Allow empty string for url-prefix

### DIFF
--- a/src/commands/community/create.ts
+++ b/src/commands/community/create.ts
@@ -56,7 +56,8 @@ export class CommunityCreateCommand extends SfCommand<CommunityCreateResponse> {
       char: 'p',
       summary: messages.getMessage('flags.urlPathPrefix.summary'),
       description: messages.getMessage('flags.urlPathPrefix.description'),
-      required: true,
+      // The api requires you to pass this, it accepts an empty string
+      default: '',
       deprecateAliases: true,
       aliases: ['urlpathprefix'],
     }),
@@ -124,6 +125,6 @@ export class CommunityCreateCommand extends SfCommand<CommunityCreateResponse> {
       [ACTION_KEY]: { header: 'Action' },
     };
     this.styledHeader(messages.getMessage('response.styleHeader'));
-    this.table([results], columns);
+    this.table([results], columns, { 'no-truncate': true });
   }
 }

--- a/test/nuts/all-commands.nut.ts
+++ b/test/nuts/all-commands.nut.ts
@@ -63,6 +63,15 @@ describe('plugin-community commands', () => {
       expect(output.result.name).to.equal(siteName);
       expect(output.result.message).to.equal('Your Site is being created.');
     });
+
+    it('creates a new community without a url-prefix (empty string)', () => {
+      const cmd = `force:community:create --name "${siteName}-no-prefix" --template-name "Aloha" --json`;
+      const output = execCmd<CommunityCreateResponse>(cmd, { ensureExitCode: 0 }).jsonOutput;
+
+      expect(output.result).to.have.all.keys(['message', 'name', 'action']);
+      expect(output.result.name).to.equal(`${siteName}-no-prefix`);
+      expect(output.result.message).to.equal('Your Site is being created.');
+    });
   });
 
   describe('community:publish', () => {


### PR DESCRIPTION
### What does this PR do?
Fixes a regression on the `--url-prefix` for `community create`. The API accepts an empty string and the `required: true` was forcing a truthy value. I removed `required: true` and changed the default to `''`.

Also added no-truncate to the table so that the suggested command is not truncated:
<img width="1057" alt="Screenshot 2023-03-22 at 8 55 16 AM" src="https://user-images.githubusercontent.com/1715111/226935840-c7f1f9e1-2609-47c1-b1d8-d79879c78947.png">


### What issues does this PR fix or reference?
[@W-12726772@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12726772)
https://github.com/forcedotcom/cli/issues/2005