### PR TITLE
244 jobstatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,25 +110,21 @@ OPTIONS
                                                                                     this command invocation
 
 DESCRIPTION
-  See 'Which Experience Cloud Template Should I Use?' in Salesforce Help for more information about the different
-  template types available for Experience Cloud.
+  Run the "community list template" command to see the templates available in your org. See 'Which Experience Cloud Template Should I Use?' in Salesforce Help for more information about the different template types available.
 
-  When creating a site with the Build Your Own (LWR) template, you must also specify the AuthenticationType value using
-  the format templateParams.AuthenticationType=value, where value is AUTHENTICATED, UNAUTHENTICATED, or
-  AUTHENTICATED_WITH_PUBLIC_ACCESS. Name and values are case-sensitive. See 'ExperienceBundle' in the Metadata API
-  Developer Guide for more information.
+  When you create a site with the Build Your Own (LWR) template, you must also specify the AuthenticationType value using the format templateParams.AuthenticationType=value, where value is AUTHENTICATED or AUTHENTICATED_WITH_PUBLIC_ACCESS_ENABLED. Name and values are case-sensitive. See 'DigitalExperienceBundle' in the Metadata API Developer Guide for more information.
 
-  When you execute this command, it creates the site in preview status, which means that it isn't yet live. After you
-  finish building your site, you can make it live.
+  The site creation process is an async job that generates a jobId. To check the site creation status, query the BackgroundOperation object and enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the Salesforce Platform for more information.
 
-  If you have an Experience Builder site, publish the site using the sfdx force:community:publish command to make it
-  live.
+  If the job doesn’t complete within 10 minutes, it times out. You receive an error message and must restart the site creation process. Completed jobs expire after 24 hours and are removed from the database.
 
-  If you have a Salesforce Tabs + Visualforce site, activate the site to make it live by updating the status field of
-  the Network type in the Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and
-  click Activate.
+  When you run this command, it creates the site in preview status, which means that the site isn't yet live. After you finish building your site, you can make it live.
 
-  For Experience Builder sites, activating the site just sends out a welcome email to site members.
+  If you have an Experience Builder site, publish the site using the "community publish" command to make it live.
+
+  If you have a Salesforce Tabs + Visualforce site, to activate the site and make it live, update the status field of the Network type in Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
+
+  For Experience Builder sites, activating the site sends a welcome email to site members.
 
 EXAMPLES
   $ sfdx force:community:create --name 'My Customer Site' --templatename 'Customer Service' --urlpathprefix customers

--- a/README.md
+++ b/README.md
@@ -110,19 +110,29 @@ OPTIONS
                                                                                     this command invocation
 
 DESCRIPTION
-  Run the "community list template" command to see the templates available in your org. See 'Which Experience Cloud Template Should I Use?' in Salesforce Help for more information about the different template types available.
+  Run the "community list template" command to see the templates available in your org. See 'Which Experience Cloud
+  Template Should I Use?' in Salesforce Help for more information about the different template types available.
 
-  When you create a site with the Build Your Own (LWR) template, you must also specify the AuthenticationType value using the format templateParams.AuthenticationType=value, where value is AUTHENTICATED or AUTHENTICATED_WITH_PUBLIC_ACCESS_ENABLED. Name and values are case-sensitive. See 'DigitalExperienceBundle' in the Metadata API Developer Guide for more information.
+  When you create a site with the Build Your Own (LWR) template, you must also specify the AuthenticationType value
+  using the format templateParams.AuthenticationType=value, where value is AUTHENTICATED or
+  AUTHENTICATED_WITH_PUBLIC_ACCESS_ENABLED. Name and values are case-sensitive. See 'DigitalExperienceBundle' in the
+  Metadata API Developer Guide for more information.
 
-  The site creation process is an async job that generates a jobId. To check the site creation status, query the BackgroundOperation object and enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the Salesforce Platform for more information.
+  The site creation process is an async job that generates a jobId. To check the site creation status, query the
+  BackgroundOperation object and enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the
+  Salesforce Platform for more information.
 
-  If the job doesn’t complete within 10 minutes, it times out. You receive an error message and must restart the site creation process. Completed jobs expire after 24 hours and are removed from the database.
+  If the job doesn’t complete within 10 minutes, it times out. You receive an error message and must restart the site
+  creation process. Completed jobs expire after 24 hours and are removed from the database.
 
-  When you run this command, it creates the site in preview status, which means that the site isn't yet live. After you finish building your site, you can make it live.
+  When you run this command, it creates the site in preview status, which means that the site isn't yet live. After you
+  finish building your site, you can make it live.
 
   If you have an Experience Builder site, publish the site using the "community publish" command to make it live.
 
-  If you have a Salesforce Tabs + Visualforce site, to activate the site and make it live, update the status field of the Network type in Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
+  If you have a Salesforce Tabs + Visualforce site, to activate the site and make it live, update the status field of
+  the Network type in Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click
+  Activate.
 
   For Experience Builder sites, activating the site sends a welcome email to site members.
 
@@ -161,13 +171,20 @@ OPTIONS
                                                                                     this command invocation
 
 DESCRIPTION
-  Each time you publish a site, you update the live site with the most recent updates. When you publish an Experience Builder site for the first time, you make the site's URL live and enable login access for site members.
+  Each time you publish a site, you update the live site with the most recent updates. When you publish an Experience
+  Builder site for the first time, you make the site's URL live and enable login access for site members.
 
-  In addition to publishing, you must activate a site to send a welcome email to all site members. Activation is also required to set up SEO for Experience Builder sites. To activate a site, update the status field of the Network type in Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
+  In addition to publishing, you must activate a site to send a welcome email to all site members. Activation is also
+  required to set up SEO for Experience Builder sites. To activate a site, update the status field of the Network type
+  in Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
 
-  An email notification informs you when your changes are live on the published site. The site publish process is an async job that generates a jobId. To check the site publish status manually, query the BackgroundOperation object and enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the Salesforce Platform for more information.
+  An email notification informs you when your changes are live on the published site. The site publish process is an
+  async job that generates a jobId. To check the site publish status manually, query the BackgroundOperation object and
+  enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the Salesforce Platform for more
+  information.
 
-  If the job doesn’t complete within 15 minutes, it times out. You receive an error message and must restart the site publish process. Completed jobs expire after 24 hours and are removed from the database.
+  If the job doesn’t complete within 15 minutes, it times out. You receive an error message and must restart the site
+  publish process. Completed jobs expire after 24 hours and are removed from the database.
 
 
 EXAMPLE

--- a/README.md
+++ b/README.md
@@ -161,19 +161,14 @@ OPTIONS
                                                                                     this command invocation
 
 DESCRIPTION
-  Each time you publish it, you update the live site with the most recent updates.
-  When you publish an Experience Builder site for the first time, you make the site's URL live and enable login access
-  for site members.
+  Each time you publish a site, you update the live site with the most recent updates. When you publish an Experience Builder site for the first time, you make the site's URL live and enable login access for site members.
 
-  Additionally, to send a welcome email to all site members, you must activate the site. (Activation is also required to
-   successfully set up SEO for Experience Builder sites.) To activate a site, update the status field of the Network
-  type in the Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click
-  Activate.
+  In addition to publishing, you must activate a site to send a welcome email to all site members. Activation is also required to set up SEO for Experience Builder sites. To activate a site, update the status field of the Network type in Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
 
-  Subsequently, each time you publish the site, you update the live site with all changes made to the site since it was
-  last published.
+  An email notification informs you when your changes are live on the published site. The site publish process is an async job that generates a jobId. To check the site publish status manually, query the BackgroundOperation object and enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the Salesforce Platform for more information.
 
-  An email notification informs you when your changes are live.
+  If the job doesn’t complete within 15 minutes, it times out. You receive an error message and must restart the site publish process. Completed jobs expire after 24 hours and are removed from the database.
+
 
 EXAMPLE
   $ sfdx force:community:publish --name 'My Customer Site'

--- a/messages/create.md
+++ b/messages/create.md
@@ -4,18 +4,21 @@ Create an Experience Cloud site using a template.
 
 # description
 
-See 'Which Experience Cloud Template Should I Use?' (https://help.salesforce.com/s/articleView?id=sf.siteforce_commtemp_intro.htm&type=5) in Salesforce Help for more information about the different template
-types available for Experience Cloud.
+Run the "community list template" command to see the templates available in your org. See 'Which Experience Cloud Template Should I Use?' in Salesforce Help for more information about the different template types available. (https://help.salesforce.com/s/articleView?id=sf.siteforce_commtemp_intro.htm&type=5)
 
-When creating a site with the Build Your Own (LWR) template, you must also specify the AuthenticationType value using the format templateParams.AuthenticationType=value, where value is AUTHENTICATED, UNAUTHENTICATED, or AUTHENTICATED_WITH_PUBLIC_ACCESS. Name and values are case-sensitive. See 'ExperienceBundle' in the Metadata API Developer Guide for more information. (https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_experiencebundle.htm)
+When you create a site with the Build Your Own (LWR) template, you must also specify the AuthenticationType value using the format templateParams.AuthenticationType=value, where value is AUTHENTICATED or AUTHENTICATED_WITH_PUBLIC_ACCESS_ENABLED. Name and values are case-sensitive. See 'DigitalExperienceBundle' in the Metadata API Developer Guide for more information. (https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_digitalexperiencebundle.htm)
 
-When you execute this command, it creates the site in preview status, which means that it isn't yet live. After you finish building your site, you can make it live.
+The site creation process is an async job that generates a jobId. To check the site creation status, query the BackgroundOperation object and enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the Salesforce Platform for more information. (https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_backgroundoperation.htm)
+
+If the job doesn’t complete within 10 minutes, it times out. You receive an error message and must restart the site creation process. Completed jobs expire after 24 hours and are removed from the database.
+
+When you run this command, it creates the site in preview status, which means that the site isn't yet live. After you finish building your site, you can make it live.
 
 If you have an Experience Builder site, publish the site using the "community publish" command to make it live.
 
-If you have a Salesforce Tabs + Visualforce site, activate the site to make it live by updating the status field of the Network type in the Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
+If you have a Salesforce Tabs + Visualforce site, to activate the site and make it live, update the status field of the Network type in Metadata API. (https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_network.htm) Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
 
-For Experience Builder sites, activating the site just sends out a welcome email to site members.
+For Experience Builder sites, activating the site sends a welcome email to site members.
 
 # examples
 

--- a/messages/create.md
+++ b/messages/create.md
@@ -64,8 +64,7 @@ The description displays in Digital Experiences - All Sites in Setup and helps w
 
 # response.action
 
-We’re creating your site. Run sfdx force:org:open -p \_ui/networks/setup/SetupNetworksPage to view a list of your sites,
-and to confirm when this site is ready.
+Site creation is under way. To track its status, query the BackgroundOperation object and include the jobId.
 
 # response.styleHeader
 

--- a/messages/publish.md
+++ b/messages/publish.md
@@ -4,13 +4,13 @@ Publish an Experience Builder site to make it live.
 
 # description
 
-Each time you publish it, you update the live site with the most recent updates. When you publish an Experience Builder site for the first time, you make the site's URL live and enable login access for site members.
+Each time you publish a site, you update the live site with the most recent updates. When you publish an Experience Builder site for the first time, you make the site's URL live and enable login access for site members.
 
-Additionally, to send a welcome email to all site members, you must activate the site. (Activation is also required to successfully set up SEO for Experience Builder sites.) To activate a site, update the status field of the Network type in the Metadata API. Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
+In addition to publishing, you must activate a site to send a welcome email to all site members. Activation is also required to set up SEO for Experience Builder sites. To activate a site, update the status field of the Network type in Metadata API. (https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_network.htm)Alternatively, in Experience Workspaces, go to Administration | Settings, and click Activate.
 
-Subsequently, each time you publish the site, you update the live site with all changes made to the site since it was last published.
+An email notification informs you when your changes are live on the published site. The site publish process is an async job that generates a jobId. To check the site publish status manually, query the BackgroundOperation object and enter the jobId as the Id. See ‘BackgroundOperation’ in the Object Reference for the Salesforce Platform for more information. (https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_backgroundoperation.htm)
 
-An email notification informs you when your changes are live.
+If the job doesn’t complete within 15 minutes, it times out. You receive an error message and must restart the site publish process. Completed jobs expire after 24 hours and are removed from the database.
 
 # examples
 

--- a/schemas/community-create.json
+++ b/schemas/community-create.json
@@ -13,6 +13,10 @@
           "type": "string",
           "description": "name of the community"
         },
+        "jobId": {
+          "type": "string",
+          "description": "id of the BackgroundOperation that runs the create job"
+        },
         "action": {
           "type": "string",
           "description": "the next actions that user can do to check, if community is created or not."

--- a/schemas/community-publish.json
+++ b/schemas/community-publish.json
@@ -24,6 +24,10 @@
         "url": {
           "type": "string",
           "description": "url to access the community"
+        },
+        "jobId": {
+          "type": "string",
+          "description": "id of the BackgroundOperation that runs the publish job"
         }
       },
       "required": ["id", "message", "name", "url"],

--- a/src/commands/community/create.ts
+++ b/src/commands/community/create.ts
@@ -24,6 +24,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-community', 'create')
 
 const MESSAGE_KEY = 'message';
 const NAME_KEY = 'name';
+const JOBID_KEY = 'jobId';
 const ACTION_KEY = 'action';
 
 /**
@@ -94,6 +95,7 @@ export class CommunityCreateCommand extends SfCommand<CommunityCreateResponse> {
     const columns = {
       [NAME_KEY]: { header: 'Name' },
       [MESSAGE_KEY]: { header: 'Message' },
+      [JOBID_KEY]: { header: 'JobId' },
       [ACTION_KEY]: { header: 'Action' },
     };
     this.styledHeader(messages.getMessage('response.styleHeader'));

--- a/src/commands/community/publish.ts
+++ b/src/commands/community/publish.ts
@@ -62,6 +62,7 @@ export class CommunityPublishCommand extends SfCommand<CommunityPublishResponse>
       name: { header: 'Name' },
       status: { header: 'Status' },
       url: { header: 'Url' },
+      jobId: { header: 'JobId' },
     };
     this.styledHeader(messages.getMessage('response.styleHeader'));
     this.table([results], columns);

--- a/src/shared/community/connect/CommunityCreateResource.ts
+++ b/src/shared/community/connect/CommunityCreateResource.ts
@@ -14,18 +14,25 @@ import { ConnectResource } from '../../connect/services/ConnectResource';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-community', 'create');
 
+<<<<<<< HEAD
+=======
+const NAME_KEY = 'name';
+const JOBID_KEY = 'jobId';
+
+>>>>>>> ba5156f (feat(create): adding job id to the creaet command)
 /**
  * A connect api resource for creating a community
  */
 export class CommunityCreateResource implements ConnectResource<CommunityCreateResponse> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(private options: CommunityCreateParams) {}
+  public constructor(private options: CommunityCreateParams) { }
 
   // eslint-disable-next-line class-methods-use-this
-  public handleSuccess(result: JsonCollection & { name: string }): CommunityCreateResponse {
+  public handleSuccess(result: JsonCollection & { [NAME_KEY]?: string; jobId?: string }): CommunityCreateResponse {
     const response: CommunityCreateResponse = {
       message: messages.getMessage('response.createMessage'),
-      name: result.name,
+      name: result[NAME_KEY],
+      jobId: result[JOBID_KEY],
       action: messages.getMessage('response.action'),
     };
     return response;

--- a/src/shared/community/connect/CommunityCreateResource.ts
+++ b/src/shared/community/connect/CommunityCreateResource.ts
@@ -14,18 +14,15 @@ import { ConnectResource } from '../../connect/services/ConnectResource';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-community', 'create');
 
-<<<<<<< HEAD
-=======
 const NAME_KEY = 'name';
 const JOBID_KEY = 'jobId';
 
->>>>>>> ba5156f (feat(create): adding job id to the creaet command)
 /**
  * A connect api resource for creating a community
  */
 export class CommunityCreateResource implements ConnectResource<CommunityCreateResponse> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(private options: CommunityCreateParams) { }
+  public constructor(private options: CommunityCreateParams) {}
 
   // eslint-disable-next-line class-methods-use-this
   public handleSuccess(

--- a/src/shared/community/connect/CommunityCreateResource.ts
+++ b/src/shared/community/connect/CommunityCreateResource.ts
@@ -28,7 +28,9 @@ export class CommunityCreateResource implements ConnectResource<CommunityCreateR
   public constructor(private options: CommunityCreateParams) { }
 
   // eslint-disable-next-line class-methods-use-this
-  public handleSuccess(result: JsonCollection & { [NAME_KEY]?: string; jobId?: string }): CommunityCreateResponse {
+  public handleSuccess(
+    result: JsonCollection & { [NAME_KEY]?: string; [JOBID_KEY]?: string }
+  ): CommunityCreateResponse {
     const response: CommunityCreateResponse = {
       message: messages.getMessage('response.createMessage'),
       name: result[NAME_KEY],

--- a/src/shared/community/connect/CommunityCreateResource.ts
+++ b/src/shared/community/connect/CommunityCreateResource.ts
@@ -25,9 +25,7 @@ export class CommunityCreateResource implements ConnectResource<CommunityCreateR
   public constructor(private options: CommunityCreateParams) {}
 
   // eslint-disable-next-line class-methods-use-this
-  public handleSuccess(
-    result: JsonCollection & { [NAME_KEY]?: string; [JOBID_KEY]?: string }
-  ): CommunityCreateResponse {
+  public handleSuccess(result: JsonCollection & { [NAME_KEY]: string; [JOBID_KEY]: string }): CommunityCreateResponse {
     const response: CommunityCreateResponse = {
       message: messages.getMessage('response.createMessage'),
       name: result[NAME_KEY],

--- a/src/shared/community/connect/CommunityPublishResource.ts
+++ b/src/shared/community/connect/CommunityPublishResource.ts
@@ -28,7 +28,7 @@ export type CommunityPublishResourceOptions = {
 export class CommunityPublishResource implements ConnectResource<CommunityPublishResponse> {
   private info?: CommunityInfo;
 
-  public constructor(private options: CommunityPublishResourceOptions) {}
+  public constructor(private options: CommunityPublishResourceOptions) { }
 
   public async fetchRelativeConnectUrl(): Promise<string> {
     return `/connect/communities/${await this.fetchCommunityId()}/publish`;
@@ -44,13 +44,16 @@ export class CommunityPublishResource implements ConnectResource<CommunityPublis
     return Promise.resolve(JSON.stringify({}));
   }
 
-  public handleSuccess(result: JsonCollection & { id: string; name: string; url: string }): CommunityPublishResponse {
+  public handleSuccess(
+    result: JsonCollection & { id?: string; name?: string; url?: string; jobId?: string }
+  ): CommunityPublishResponse {
     return {
       id: result.id,
       message: messages.getMessage('response.message'),
       name: result.name,
       status: this.info?.status,
       url: new URL(result.url).toString(),
+      jobId: result.jobId,
     };
   }
 

--- a/src/shared/community/connect/CommunityPublishResource.ts
+++ b/src/shared/community/connect/CommunityPublishResource.ts
@@ -28,7 +28,7 @@ export type CommunityPublishResourceOptions = {
 export class CommunityPublishResource implements ConnectResource<CommunityPublishResponse> {
   private info?: CommunityInfo;
 
-  public constructor(private options: CommunityPublishResourceOptions) { }
+  public constructor(private options: CommunityPublishResourceOptions) {}
 
   public async fetchRelativeConnectUrl(): Promise<string> {
     return `/connect/communities/${await this.fetchCommunityId()}/publish`;
@@ -45,7 +45,7 @@ export class CommunityPublishResource implements ConnectResource<CommunityPublis
   }
 
   public handleSuccess(
-    result: JsonCollection & { id?: string; name?: string; url?: string; jobId?: string }
+    result: JsonCollection & { id: string; name: string; url: string; jobId: string }
   ): CommunityPublishResponse {
     return {
       id: result.id,

--- a/src/shared/community/defs/CommunityCreateResponse.ts
+++ b/src/shared/community/defs/CommunityCreateResponse.ts
@@ -22,7 +22,7 @@ export type CommunityCreateResponse = {
   /**
    * id of the BackgroundOperation that runs the create job
    */
-  jobId: string;
+  jobId?: string;
 
   /**
    * the next actions that user can do to check, if community is created or not.

--- a/src/shared/community/defs/CommunityCreateResponse.ts
+++ b/src/shared/community/defs/CommunityCreateResponse.ts
@@ -20,6 +20,11 @@ export type CommunityCreateResponse = {
   name: string;
 
   /**
+   * id of the BackgroundOperation that runs the create job
+   */
+  jobId: string;
+
+  /**
    * the next actions that user can do to check, if community is created or not.
    */
   action: string;

--- a/src/shared/community/defs/CommunityPublishResponse.ts
+++ b/src/shared/community/defs/CommunityPublishResponse.ts
@@ -34,4 +34,9 @@ export type CommunityPublishResponse = {
    * url to access the community
    */
   url: string;
+
+  /**
+   * id of the BackgroundOperation that runs the publish job
+   */
+  jobId: string;
 };

--- a/src/shared/community/defs/CommunityPublishResponse.ts
+++ b/src/shared/community/defs/CommunityPublishResponse.ts
@@ -38,5 +38,5 @@ export type CommunityPublishResponse = {
   /**
    * id of the BackgroundOperation that runs the publish job
    */
-  jobId: string;
+  jobId?: string;
 };

--- a/test/shared/community/connect/CommunityCreateResource.test.ts
+++ b/test/shared/community/connect/CommunityCreateResource.test.ts
@@ -69,7 +69,7 @@ describe('CommunityCreateResource', () => {
 
   describe('handleSuccess', () => {
     it('should return community info', () => {
-      const connectResponse: JsonCollection = {
+      const connectResponse: JsonMap = {
         name: communityName,
         jobId,
       };

--- a/test/shared/community/connect/CommunityCreateResource.test.ts
+++ b/test/shared/community/connect/CommunityCreateResource.test.ts
@@ -22,6 +22,7 @@ describe('CommunityCreateResource', () => {
   const urlPathPrefix = 'urlPathPrefix';
   const templateName = 'templateName';
   const description = 'description';
+  const jobId = '000xx0000000000000';
   let table: sinon.SinonStub;
   let styledHeader: sinon.SinonStub;
 
@@ -68,14 +69,15 @@ describe('CommunityCreateResource', () => {
 
   describe('handleSuccess', () => {
     it('should return community info', () => {
-      const connectResponse = {
-        message: 'message',
+      const connectResponse: JsonCollection = {
         name: communityName,
+        jobId,
       };
 
       const result: CommunityCreateResponse = communityCreateResource.handleSuccess(connectResponse);
       expect(result.message).to.equal(messages.getMessage('response.createMessage'));
       expect(result.name).to.equal(communityName);
+      expect(result.jobId).to.equal(jobId);
       expect(result.action).to.equal(messages.getMessage('response.action'));
     });
   });

--- a/test/shared/community/connect/CommunityCreateResource.test.ts
+++ b/test/shared/community/connect/CommunityCreateResource.test.ts
@@ -69,7 +69,7 @@ describe('CommunityCreateResource', () => {
 
   describe('handleSuccess', () => {
     it('should return community info', () => {
-      const connectResponse: JsonMap = {
+      const connectResponse = {
         name: communityName,
         jobId,
       };

--- a/test/shared/community/connect/CommunityPublishResource.test.ts
+++ b/test/shared/community/connect/CommunityPublishResource.test.ts
@@ -21,6 +21,7 @@ describe('CommunityPublishResource', () => {
   let org: Org;
   let communityPublishResource: CommunityPublishResource;
   const communityName = 'communityName';
+  const jobId = '000xx0000000000000';
   const validCommunityId = '0DB0000000000';
   let table: sinon.SinonStub;
   let styledHeader: sinon.SinonStub;
@@ -104,6 +105,7 @@ describe('CommunityPublishResource', () => {
         message: 'message',
         name: communityName,
         url: 'http://someurl.com/s',
+        jobId,
       };
       // This sets up CommunityInfo
       await communityPublishResource.fetchCommunityId();
@@ -115,6 +117,7 @@ describe('CommunityPublishResource', () => {
       expect(result.name).to.equal(communityName);
       expect(result.status).to.equal('UnderConstruction');
       expect(result.url.toString()).to.equal('http://someurl.com/s');
+      expect(result.jobId).to.equal(jobId);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Updating the responses of "sf community create" and "sf community publish" to include a JobId field which contains an UDD Id of a BackgroundOperation. This JobId can be used to query the status of the job (create and publish are async operations)

Usage examples in https://salesforce.quip.com/asZ1A4kg3TJc

Connect API DRB thread: https://salesforce-internal.slack.com/archives/C01P2PKPJ6B/p1674175878892129

### What issues does this PR fix or reference?

None.
