### PR TITLE
test: nuts know about new property

### DIFF
--- a/test/nuts/all-commands.nut.ts
+++ b/test/nuts/all-commands.nut.ts
@@ -54,12 +54,13 @@ describe('plugin-community commands', () => {
   });
 
   describe('community:create', () => {
+    const createResultProps = ['message', 'name', 'action', 'jobId'];
     it('creates a new community', () => {
       const cmd = `force:community:create --name "${siteName}" --template-name "Aloha" --url-path-prefix "myprefix" --json`;
       const output = execCmd<CommunityCreateResponse>(cmd, { ensureExitCode: 0 }).jsonOutput;
       assert(output);
 
-      expect(output.result).to.have.all.keys(['message', 'name', 'action']);
+      expect(output.result).to.have.all.keys(createResultProps);
       expect(output.result.name).to.equal(siteName);
       expect(output.result.message).to.equal('Your Site is being created.');
     });
@@ -69,7 +70,7 @@ describe('plugin-community commands', () => {
       const output = execCmd<CommunityCreateResponse>(cmd, { ensureExitCode: 0 }).jsonOutput;
       assert(output);
 
-      expect(output.result).to.have.all.keys(['message', 'name', 'action']);
+      expect(output.result).to.have.all.keys(createResultProps);
       expect(output.result.name).to.equal(`${siteName}-no-prefix`);
       expect(output.result.message).to.equal('Your Site is being created.');
     });


### PR DESCRIPTION
### What does this PR do?
add the jobId property to the NUT expectation

### What issues does this PR fix or reference?
https://github.com/salesforcecli/sfdx-cli/actions/runs/5250678211/jobs/9485301880#step:6:102